### PR TITLE
Bugfix: enforce namespace flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ test:
 build:
 	go install ./cmd/ksec/
 
-.PHONY: install-plugin-locally
-install-plugin-locally: build
+.PHONY: install-plugin-local
+install-plugin-local: build
 	helm plugin remove $(CMD_NAME) || true
 	HELM_PLUGIN_BUILD_SOURCE=1 helm plugin install $(shell pwd)
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,11 @@ test:
 build:
 	go install ./cmd/ksec/
 
+.PHONY: install-plugin-locally
+install-plugin-locally: build
+	helm plugin remove $(CMD_NAME) || true
+	HELM_PLUGIN_BUILD_SOURCE=1 helm plugin install $(shell pwd)
+
 .PHONY: dist
 dist: dist-setup dist-linux dist-darwin dist-windows ## Cross compile binaries into ./dist/
 

--- a/cmd/ksec/main.go
+++ b/cmd/ksec/main.go
@@ -57,7 +57,13 @@ func NewRootCmd() *cobra.Command {
 		Version: version.Get().Version,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			var err error
-			secretsClient, err = models.NewSecretsClient(viper.GetString("namespace"))
+			namespace := viper.GetString("namespace")
+
+			if namespace == "" {
+				namespace = os.Getenv("HELM_NAMESPACE")
+			}
+
+			secretsClient, err = models.NewSecretsClient(namespace)
 			if err != nil {
 				log.Fatal(err.Error())
 			}

--- a/cmd/ksec/main.go
+++ b/cmd/ksec/main.go
@@ -59,7 +59,8 @@ func NewRootCmd() *cobra.Command {
 			var err error
 			namespace := viper.GetString("namespace")
 
-			if namespace == "" {
+			// sets namespace when used as a helm plugin since helm hijacks the "--namespace" flag.
+			if namespace == "" && os.Getenv("HELM_NAMESPACE") != "" {
 				namespace = os.Getenv("HELM_NAMESPACE")
 			}
 

--- a/cmd/ksec/main_test.go
+++ b/cmd/ksec/main_test.go
@@ -21,7 +21,7 @@ func TestMain(m *testing.M) {
 		Short: "A tool for managing Kubernetes Secret data",
 	}
 	initRootCmd(rootCmd)
-	secretsClient = models.MockNewSecretsClient()
+	secretsClient = models.MockNewSecretsClient("default")
 	os.Exit(m.Run())
 
 }

--- a/cmd/ksec/main_test.go
+++ b/cmd/ksec/main_test.go
@@ -21,7 +21,8 @@ func TestMain(m *testing.M) {
 		Short: "A tool for managing Kubernetes Secret data",
 	}
 	initRootCmd(rootCmd)
-	secretsClient = models.MockNewSecretsClient("default")
+	mockConfig := models.MockClientConfig()
+	secretsClient, _ = models.MockNewSecretsClient(mockConfig, "default")
 	os.Exit(m.Run())
 }
 

--- a/cmd/ksec/main_test.go
+++ b/cmd/ksec/main_test.go
@@ -52,13 +52,7 @@ func TestCreateSecret(t *testing.T) {
 func TestUnsetSecretKey(t *testing.T) {
 	ctx := context.Background()
 
-	// Create/Set the secret
-	err := cmdExec([]string{"create", "test"})
-	assert.NoError(t, err, "Creating secret should not return an error")
-	err = cmdExec([]string{"set", "test", "key=value"})
-	assert.NoError(t, err, "Setting secret key should not return an error")
-
-	err = cmdExec([]string{"unset", "test", "key"})
+	err := cmdExec([]string{"unset", "test", "key"})
 	assert.NoError(t, err, "Unsetting secret key should not return an error")
 
 	secret, err := secretsClient.Get(ctx, "test")

--- a/cmd/ksec/main_test.go
+++ b/cmd/ksec/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"context"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -83,7 +82,7 @@ func TestPushSecret(t *testing.T) {
 	ctx := context.Background()
 	content := []byte("ENV_VAR=secret")
 
-	tempfile, err := ioutil.TempFile("", "ksec")
+	tempfile, err := os.CreateTemp("", "ksec")
 	assert.NoError(t, err, "Creating temp file should not return an error")
 	defer os.Remove(tempfile.Name())
 
@@ -106,7 +105,7 @@ func TestPushSecret(t *testing.T) {
 }
 
 func TestPullSecret(t *testing.T) {
-	tempfile, err := ioutil.TempFile("", "ksec")
+	tempfile, err := os.CreateTemp("", "ksec")
 	assert.NoError(t, err, "Creating temp file should not return an error")
 	defer os.Remove(tempfile.Name())
 

--- a/cmd/ksec/main_test.go
+++ b/cmd/ksec/main_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kanopy-platform/ksec/pkg/models"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 )
 
 // mock rootCmd
@@ -23,22 +24,11 @@ func TestMain(m *testing.M) {
 	initRootCmd(rootCmd)
 	secretsClient = models.MockNewSecretsClient("default")
 	os.Exit(m.Run())
-
-}
-
-// helpers
-func testErr(err error, t *testing.T) {
-	if err != nil {
-		t.Fatal(err)
-	}
 }
 
 func cmdExec(args []string) error {
 	rootCmd.SetArgs(args)
-	if err := rootCmd.Execute(); err != nil {
-		return err
-	}
-	return nil
+	return rootCmd.Execute()
 }
 
 // tests
@@ -46,88 +36,93 @@ func TestCreateSecret(t *testing.T) {
 	ctx := context.Background()
 
 	err := cmdExec([]string{"create", "test"})
-	testErr(err, t)
+	assert.NoError(t, err, "Creating secret should not return an error")
 
 	err = cmdExec([]string{"set", "test", "key=value"})
-	testErr(err, t)
+	assert.NoError(t, err, "Setting secret key should not return an error")
 
 	secret, err := secretsClient.Get(ctx, "test")
-	testErr(err, t)
+	assert.NoError(t, err, "Getting secret should not return an error")
+	assert.NotNil(t, secret, "Secret should not be nil")
 
 	val, ok := secret.Data["key"]
-	if !ok {
-		t.Fatal("Key does not exist")
-	} else if string(val) != "value" {
-		t.Fatal("Key has incorrect value")
-	}
+	assert.True(t, ok, "Key should exist in secret data")
+	assert.Equal(t, "value", string(val), "Key should have the correct value")
 }
 
 func TestUnsetSecretKey(t *testing.T) {
 	ctx := context.Background()
-	err := cmdExec([]string{"unset", "test", "key"})
-	testErr(err, t)
+
+	// Create/Set the secret
+	err := cmdExec([]string{"create", "test"})
+	assert.NoError(t, err, "Creating secret should not return an error")
+	err = cmdExec([]string{"set", "test", "key=value"})
+	assert.NoError(t, err, "Setting secret key should not return an error")
+
+	err = cmdExec([]string{"unset", "test", "key"})
+	assert.NoError(t, err, "Unsetting secret key should not return an error")
 
 	secret, err := secretsClient.Get(ctx, "test")
-	testErr(err, t)
+	assert.NoError(t, err, "Getting secret should not return an error")
+	assert.NotNil(t, secret, "Secret should not be nil")
 
-	if _, ok := secret.Data["key"]; ok {
-		t.Fatal("Key should not exist")
-	}
+	_, ok := secret.Data["key"]
+	assert.False(t, ok, "Key should not exist in secret data")
 }
 
 func TestDeleteSecret(t *testing.T) {
 	err := cmdExec([]string{"delete", "test", "--yes"})
-	testErr(err, t)
+	assert.NoError(t, err, "Deleting secret should not return an error")
 
 	err = cmdExec([]string{"get", "test"})
-	if !strings.HasSuffix(err.Error(), "not found") {
-		t.Fatal("Secret still exists")
-	}
+	assert.Error(t, err, "Getting deleted secret should return an error")
+	assert.True(t, strings.HasSuffix(err.Error(), "not found"), "Error should indicate that the secret was not found")
 }
 
 func TestPushSecret(t *testing.T) {
 	ctx := context.Background()
 	content := []byte("ENV_VAR=secret")
+
 	tempfile, err := ioutil.TempFile("", "ksec")
-	testErr(err, t)
+	assert.NoError(t, err, "Creating temp file should not return an error")
 	defer os.Remove(tempfile.Name())
 
 	_, err = tempfile.Write(content)
-	testErr(err, t)
+	assert.NoError(t, err, "Writing to temp file should not return an error")
 
 	err = cmdExec([]string{"push", tempfile.Name(), "pushtest"})
-	testErr(err, t)
+	assert.NoError(t, err, "Pushing secret should not return an error")
 
 	secret, err := secretsClient.Get(ctx, "pushtest")
-	testErr(err, t)
+	assert.NoError(t, err, "Getting pushed secret should not return an error")
+	assert.NotNil(t, secret, "Pushed secret should not be nil")
 
 	val, ok := secret.Data["ENV_VAR"]
-	if !ok {
-		t.Fatal("Key does not exist")
-	} else if string(val) != "secret" {
-		t.Fatal("Key has incorrect value")
-	}
+	assert.True(t, ok, "ENV_VAR key should exist in pushed secret data")
+	assert.Equal(t, "secret", string(val), "ENV_VAR key should have the correct value")
 
 	err = tempfile.Close()
-	testErr(err, t)
+	assert.NoError(t, err, "Closing temp file should not return an error")
 }
 
 func TestPullSecret(t *testing.T) {
 	tempfile, err := ioutil.TempFile("", "ksec")
-	testErr(err, t)
+	assert.NoError(t, err, "Creating temp file should not return an error")
 	defer os.Remove(tempfile.Name())
 
 	err = cmdExec([]string{"set", "pulltest", "ENV_VAR=secret"})
-	testErr(err, t)
+	assert.NoError(t, err, "Setting secret should not return an error")
 
 	err = cmdExec([]string{"pull", "pulltest", tempfile.Name()})
-	testErr(err, t)
+	assert.NoError(t, err, "Pulling secret should not return an error")
 
-	reader := bufio.NewReader(tempfile)
+	file, err := os.Open(tempfile.Name())
+	assert.NoError(t, err, "Opening temp file should not return an error")
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
 	line, _, err := reader.ReadLine()
-	testErr(err, t)
+	assert.NoError(t, err, "Reading line from temp file should not return an error")
 
-	if string(line) != "ENV_VAR=secret" {
-		t.Fatal("File does not contain pulled contents")
-	}
+	assert.Equal(t, "ENV_VAR=secret", string(line), "File should contain the pulled secret contents")
 }

--- a/pkg/models/secrets_client.go
+++ b/pkg/models/secrets_client.go
@@ -40,6 +40,13 @@ func NewSecretsClient(namespace string) (*SecretsClient, error) {
 		return nil, err
 	}
 
+	if namespace == "" {
+		namespace, _, err = kubeConfig.Namespace()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &SecretsClient{
 		secretInterface: clientSet.CoreV1().Secrets(namespace),
 		Namespace:       namespace,

--- a/pkg/models/secrets_client.go
+++ b/pkg/models/secrets_client.go
@@ -40,13 +40,6 @@ func NewSecretsClient(namespace string) (*SecretsClient, error) {
 		return nil, err
 	}
 
-	if namespace == "" {
-		namespace, _, err = kubeConfig.Namespace()
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return &SecretsClient{
 		secretInterface: clientSet.CoreV1().Secrets(namespace),
 		Namespace:       namespace,

--- a/pkg/models/secrets_client_test.go
+++ b/pkg/models/secrets_client_test.go
@@ -11,15 +11,27 @@ import (
 var secretsClient *SecretsClient
 var expectedSecretName = "test-secret"
 var defaultNamespace = "default"
+var err error
 
 // setupTestClient initializes a new secretsClient before each test
 func setupTestClient(namespace string) {
-	secretsClient = MockNewSecretsClient(namespace)
+	mockConfig := MockClientConfig()
+	secretsClient, err = MockNewSecretsClient(mockConfig, namespace)
 }
 
 func TestNewSecretsClient(t *testing.T) {
 	setupTestClient(defaultNamespace)
-	assert.Equal(t, "default", secretsClient.Namespace, "Namespace should be %s", defaultNamespace)
+
+	assert.NoError(t, err)
+	assert.Equal(t, defaultNamespace, secretsClient.Namespace)
+	assert.Equal(t, "testuser", secretsClient.AuthInfo)
+	assert.NotNil(t, secretsClient.secretInterface)
+}
+
+func TestNewSecretsClientUndefinedNamespace(t *testing.T) {
+	// undefined namespace, expected to fail
+	setupTestClient("")
+	assert.Error(t, err)
 }
 
 func TestCreate(t *testing.T) {

--- a/pkg/models/secrets_client_test.go
+++ b/pkg/models/secrets_client_test.go
@@ -4,110 +4,139 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var secretsClient *SecretsClient
+var expectedSecretName = "test-secret"
 
-// helpers
-func testErr(err error, t *testing.T) {
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+// setupTestClient initializes a new secretsClient before each test
+func setupTestClient(namespace string) {
+	secretsClient = MockNewSecretsClient(namespace)
 }
 
-// unit tests
 func TestNewSecretsClient(t *testing.T) {
-	secretsClient = MockNewSecretsClient()
+	setupTestClient("default")
+	assert.Equal(t, "default", secretsClient.Namespace, "Namespace should be 'default'")
 }
 
 func TestCreate(t *testing.T) {
+	setupTestClient("default")
 	ctx := context.Background()
-	_, err := secretsClient.Create(ctx, "test-secret")
-	testErr(err, t)
+
+	secret, err := secretsClient.Create(ctx, expectedSecretName)
+	assert.NoError(t, err, "Creating secret should not return an error")
+
+	assert.NotNil(t, secret, "Created secret should not be nil")
+	assert.Equal(t, secret.Name, expectedSecretName)
 }
 
 func TestList(t *testing.T) {
+	setupTestClient("default")
 	ctx := context.Background()
-	secrets, err := secretsClient.List(ctx)
-	testErr(err, t)
 
-	if secrets.Items[0].Name != "test-secret" {
-		t.Fatal(err.Error())
-	}
+	_, err := secretsClient.Create(ctx, expectedSecretName)
+	assert.NoError(t, err, "Creating secret should not return an error")
+
+	secrets, err := secretsClient.List(ctx)
+	assert.NoError(t, err, "Listing secrets should not return an error")
+	assert.NotEmpty(t, secrets.Items, "Secrets list should not be empty")
+	assert.Equal(t, expectedSecretName, secrets.Items[0].Name, "First secret name should be %s", expectedSecretName)
 }
 
 func TestCreateWithData(t *testing.T) {
+	setupTestClient("default")
+	ctx := context.Background()
+
 	dataArgs := []string{
 		"key=value",
 		"secret-key=secret-value",
 		"ENV_VAR=~!@#$%^&*()_+",
 		"DB_URL=mongodb://host1.example.com:27017,host2.example.com:27017/prod?replicaSet=prod",
 	}
+
 	data := make(map[string][]byte)
 
 	for _, item := range dataArgs {
 		split := strings.SplitN(item, "=", 2)
-		if len(split) != 2 {
-			t.Errorf("Data is not formatted correctly: %s", item)
-		}
+		assert.Len(t, split, 2, "Data is not formatted correctly")
 		data[split[0]] = []byte(split[1])
 	}
 
-	ctx := context.Background()
-	_, err := secretsClient.CreateWithData(ctx, "test-secret-with-data", data)
-	testErr(err, t)
+	secret, err := secretsClient.CreateWithData(ctx, expectedSecretName, data)
+	assert.NoError(t, err, "Creating secret with data should not return an error")
+
+	assert.NotNil(t, secret.Data, "Created secret with data should not be nil")
+	assert.Equal(t, data, secret.Data)
 }
 
 func TestGet(t *testing.T) {
+	setupTestClient("default")
 	ctx := context.Background()
-	secret, err := secretsClient.Get(ctx, "test-secret-with-data")
-	testErr(err, t)
 
-	if string(secret.Data["DB_URL"]) != "mongodb://host1.example.com:27017,host2.example.com:27017/prod?replicaSet=prod" {
-		t.Fatal(err.Error())
-	}
+	_, err := secretsClient.CreateWithData(ctx, expectedSecretName, map[string][]byte{
+		"DB_URL": []byte("mongodb://host1.example.com:27017,host2.example.com:27017/prod?replicaSet=prod"),
+	})
+	assert.NoError(t, err, "Creating secret with data should not return an error")
+
+	secret, err := secretsClient.Get(ctx, expectedSecretName)
+	assert.NoError(t, err, "Getting secret should not return an error")
+	assert.Equal(t, "mongodb://host1.example.com:27017,host2.example.com:27017/prod?replicaSet=prod", string(secret.Data["DB_URL"]), "DB_URL should match the expected value")
 }
 
 func TestGetKey(t *testing.T) {
+	setupTestClient("default")
 	ctx := context.Background()
-	value, err := secretsClient.GetKey(ctx, "test-secret-with-data", "secret-key")
-	testErr(err, t)
 
-	if value != "secret-value" {
-		t.Fatal(err.Error())
-	}
+	_, err := secretsClient.CreateWithData(ctx, expectedSecretName, map[string][]byte{
+		"secret-key": []byte("secret-value"),
+	})
+	assert.NoError(t, err, "Creating secret with data should not return an error")
 
-	value, err = secretsClient.GetKey(ctx, "test-secret-with_data", "thiskeydoesnotexist")
-	if err == nil {
-		t.Fatal("non-existent key should have received an error")
-	}
+	value, err := secretsClient.GetKey(ctx, expectedSecretName, "secret-key")
+	assert.NoError(t, err, "Getting secret key should not return an error")
+	assert.Equal(t, "secret-value", value, "Secret key value should match the expected value")
+
+	value, err = secretsClient.GetKey(ctx, expectedSecretName, "thiskeydoesnotexist")
+	assert.Error(t, err, "Getting a non-existent key should return an error")
+	assert.Empty(t, value, "Non-existent key should return an empty value")
 }
 
 func TestUpdate(t *testing.T) {
+	setupTestClient("default")
 	ctx := context.Background()
-	secret, err := secretsClient.Get(ctx, "test-secret-with-data")
-	testErr(err, t)
+
+	secret, err := secretsClient.CreateWithData(ctx, expectedSecretName, map[string][]byte{
+		"key": []byte("oldvalue"),
+	})
+	assert.NoError(t, err, "Creating secret with data should not return an error")
 
 	data := map[string][]byte{
 		"key": []byte("newvalue"),
 	}
 
-	secretsClient.Update(ctx, secret, data)
-
-	if string(secret.Data["key"]) != "newvalue" {
-		t.Fatal(err.Error())
-	}
+	secret, err = secretsClient.Update(ctx, secret, data)
+	assert.NoError(t, err, "Updating secret should not return an error")
+	assert.Equal(t, "newvalue", string(secret.Data["key"]), "Key value should be updated to 'newvalue'")
 }
 
 func TestUpsert(t *testing.T) {
+	setupTestClient("default")
+	ctx := context.Background()
+
 	data := map[string][]byte{
 		"key": []byte("upsert"),
 	}
-	ctx := context.Background()
-	secret, err := secretsClient.Upsert(ctx, "upsert-secret", data)
-	testErr(err, t)
 
-	if string(secret.Data["key"]) != "upsert" {
-		t.Fatal(err.Error())
-	}
+	// First upsert (should create the secret)
+	secret, err := secretsClient.Upsert(ctx, expectedSecretName, data)
+	assert.NoError(t, err, "Upserting (creating) secret should not return an error")
+	assert.Equal(t, "upsert", string(secret.Data["key"]), "Key value should be 'upsert'")
+
+	// Second upsert (should update the secret)
+	data["key"] = []byte("upserted")
+	secret, err = secretsClient.Upsert(ctx, expectedSecretName, data)
+	assert.NoError(t, err, "Upserting (updating) secret should not return an error")
+	assert.Equal(t, "upserted", string(secret.Data["key"]), "Key value should be 'upserted'")
 }

--- a/pkg/models/secrets_client_test.go
+++ b/pkg/models/secrets_client_test.go
@@ -10,6 +10,7 @@ import (
 
 var secretsClient *SecretsClient
 var expectedSecretName = "test-secret"
+var defaultNamespace = "default"
 
 // setupTestClient initializes a new secretsClient before each test
 func setupTestClient(namespace string) {
@@ -17,12 +18,12 @@ func setupTestClient(namespace string) {
 }
 
 func TestNewSecretsClient(t *testing.T) {
-	setupTestClient("default")
-	assert.Equal(t, "default", secretsClient.Namespace, "Namespace should be 'default'")
+	setupTestClient(defaultNamespace)
+	assert.Equal(t, "default", secretsClient.Namespace, "Namespace should be %s", defaultNamespace)
 }
 
 func TestCreate(t *testing.T) {
-	setupTestClient("default")
+	setupTestClient(defaultNamespace)
 	ctx := context.Background()
 
 	secret, err := secretsClient.Create(ctx, expectedSecretName)
@@ -33,7 +34,7 @@ func TestCreate(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
-	setupTestClient("default")
+	setupTestClient(defaultNamespace)
 	ctx := context.Background()
 
 	_, err := secretsClient.Create(ctx, expectedSecretName)
@@ -46,7 +47,7 @@ func TestList(t *testing.T) {
 }
 
 func TestCreateWithData(t *testing.T) {
-	setupTestClient("default")
+	setupTestClient(defaultNamespace)
 	ctx := context.Background()
 
 	dataArgs := []string{
@@ -72,7 +73,7 @@ func TestCreateWithData(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	setupTestClient("default")
+	setupTestClient(defaultNamespace)
 	ctx := context.Background()
 
 	_, err := secretsClient.CreateWithData(ctx, expectedSecretName, map[string][]byte{
@@ -86,7 +87,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestGetKey(t *testing.T) {
-	setupTestClient("default")
+	setupTestClient(defaultNamespace)
 	ctx := context.Background()
 
 	_, err := secretsClient.CreateWithData(ctx, expectedSecretName, map[string][]byte{
@@ -104,7 +105,7 @@ func TestGetKey(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	setupTestClient("default")
+	setupTestClient(defaultNamespace)
 	ctx := context.Background()
 
 	secret, err := secretsClient.CreateWithData(ctx, expectedSecretName, map[string][]byte{
@@ -122,7 +123,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestUpsert(t *testing.T) {
-	setupTestClient("default")
+	setupTestClient(defaultNamespace)
 	ctx := context.Background()
 
 	data := map[string][]byte{

--- a/pkg/models/secrets_client_testing.go
+++ b/pkg/models/secrets_client_testing.go
@@ -2,12 +2,33 @@ package models
 
 import (
 	testclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 )
 
-func MockNewSecretsClient(namespace string) *SecretsClient {
+func MockNewSecretsClient(config clientcmd.ClientConfig, namespace string) (*SecretsClient, error) {
+	if namespace == "" {
+		_, _, err := config.Namespace()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &SecretsClient{
 		secretInterface: testclient.NewSimpleClientset().CoreV1().Secrets(namespace),
 		Namespace:       namespace,
 		AuthInfo:        "testuser",
-	}
+	}, nil
+}
+
+// Mock ClientConfig for context checks
+func MockClientConfig() clientcmd.ClientConfig {
+	return clientcmd.NewDefaultClientConfig(api.Config{
+		Contexts: map[string]*api.Context{
+			"default-context": {
+				Namespace: "default",
+			},
+		},
+		CurrentContext: "default-context",
+	}, &clientcmd.ConfigOverrides{})
 }

--- a/pkg/models/secrets_client_testing.go
+++ b/pkg/models/secrets_client_testing.go
@@ -4,11 +4,11 @@ import (
 	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
-// mock client
-func MockNewSecretsClient() *SecretsClient {
+// MockNewSecretsClient creates a new SecretsClient with a mock Kubernetes client
+func MockNewSecretsClient(namespace string) *SecretsClient {
 	return &SecretsClient{
-		secretInterface: testclient.NewSimpleClientset().CoreV1().Secrets("default"),
-		Namespace:       "default",
+		secretInterface: testclient.NewSimpleClientset().CoreV1().Secrets(namespace),
+		Namespace:       namespace,
 		AuthInfo:        "testuser",
 	}
 }

--- a/pkg/models/secrets_client_testing.go
+++ b/pkg/models/secrets_client_testing.go
@@ -4,7 +4,6 @@ import (
 	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
-// MockNewSecretsClient creates a new SecretsClient with a mock Kubernetes client
 func MockNewSecretsClient(namespace string) *SecretsClient {
 	return &SecretsClient{
 		secretInterface: testclient.NewSimpleClientset().CoreV1().Secrets(namespace),

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 ---
 name: "ksec"
-version: "0.1.7"
+version: "0.1.8"
 usage: "Manage Kubernetes Secrets through Helm"
 description: "Helm plugin that simplifies the management of Kubernetes Secrets"
 ignoreFlags: false

--- a/scripts/install-binary.sh
+++ b/scripts/install-binary.sh
@@ -6,6 +6,14 @@ if [ -n "${HELM_LINTER_PLUGIN_NO_INSTALL_HOOK}" ]; then
 fi
 
 PROJECT_NAME="ksec"
+
+if [ -n "${HELM_PLUGIN_BUILD_SOURCE}" ]; then
+    echo "Building and installing from local source."
+    cd $HELM_PLUGIN_DIR
+    go build -o "$HELM_PLUGIN_DIR/$PROJECT_NAME" ./cmd/$PROJECT_NAME/
+    exit 0
+fi
+
 PROJECT_GH="kanopy-platform/$PROJECT_NAME"
 
 : ${HELM_PLUGIN_PATH:="$(pwd)/${PROJECT_NAME}"}


### PR DESCRIPTION
- Fixes an unwanted behaviour where the namespace flag was hijacked by the Helm command
- Some unit tests needed love

Tested by 
- installing plugin from source (you can use `make install-plugin-local` to help)
- switching kubeconfig context to anything other than default. i.e namespace=opa
- running `helm ksec ls -n <any-other-namespace>` to confirm that HELM_NAMESPACE isn't overriding the namespace flag